### PR TITLE
ignore goreport card

### DIFF
--- a/config/markdown-link-check-scripts.json
+++ b/config/markdown-link-check-scripts.json
@@ -8,6 +8,9 @@
         },
         {
             "pattern": "^https://goreportcard.com/badge/github.com/dragonflyoss/Dragonfly"
-        }
+        },
+	{
+	   "pattern": "^https://goreportcard.com/report/github.com/dragonflyoss/Dragonfly"
+	}
     ]
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>
see circleci
https://circleci.com/gh/dragonflyoss/Dragonfly/10257?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link
We have to ignore `https://goreportcard.com/report/github.com/dragonflyoss/Dragonfly` too